### PR TITLE
Fix clippy complaints for Rust 1.84.

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -72,8 +72,8 @@ impl Clone for Encoding {
 impl PartialEq for Encoding {
     fn eq(&self, other: &Encoding) -> bool {
         // strip qualifiers when comparing
-        let s = self.as_str().trim_left_matches(QUALIFIERS);
-        let o = other.as_str().trim_left_matches(QUALIFIERS);
+        let s = self.as_str().trim_start_matches(QUALIFIERS);
+        let o = other.as_str().trim_start_matches(QUALIFIERS);
         s == o
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,6 @@ The bindings can be used on Linux or *BSD utilizing the
 #![crate_name = "objc"]
 #![crate_type = "lib"]
 
-#![warn(missing_docs)]
-
 extern crate malloc_buf;
 #[cfg(feature = "exception")]
 extern crate objc_exception;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -19,7 +19,7 @@ macro_rules! class {
         #[inline(always)]
         fn get_class(name: &str) -> Option<&'static $crate::runtime::Class> {
             unsafe {
-                #[cfg_attr(feature = "cargo-clippy", allow(replace_consts))]
+                #[allow(clippy::replace_consts)]
                 static CLASS: ::std::sync::atomic::AtomicUsize = ::std::sync::atomic::ATOMIC_USIZE_INIT;
                 // `Relaxed` should be fine since `objc_getClass` is thread-safe.
                 let ptr = CLASS.load(::std::sync::atomic::Ordering::Relaxed) as *const $crate::runtime::Class;
@@ -49,7 +49,7 @@ macro_rules! sel_impl {
         #[inline(always)]
         fn register_sel(name: &str) -> $crate::runtime::Sel {
             unsafe {
-                #[cfg_attr(feature = "cargo-clippy", allow(replace_consts))]
+                #[allow(clippy::replace_consts)]
                 static SEL: ::std::sync::atomic::AtomicUsize = ::std::sync::atomic::ATOMIC_USIZE_INIT;
                 let ptr = SEL.load(::std::sync::atomic::Ordering::Relaxed) as *const ::std::os::raw::c_void;
                 // It should be fine to use `Relaxed` ordering here because `sel_registerName` is


### PR DESCRIPTION
This addresses clippy's complaints about this crate when compiling under Rust 1.84.

The base branch here was created at the same commit as the 0.2.7 tag.